### PR TITLE
Fix request body passing when using delay (for non-delayed it already works)

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ const makeServer = ({ port, localIp }) => {
           }
         );
         if (delay) {
-          proxyReq.on("response", proxyRes => {
+          req.pipe(proxyReq).on("response", proxyRes => {
             proxyRes.pause();
             setTimeout(() => {
               proxyRes.pipe(res);


### PR DESCRIPTION
... see the following line for the non-delay request body passing.

https://github.com/topheman/delay-proxy/blob/e428d0ce3ce132dcb171aec8edfc3c1a7d8a673a/index.js#L49